### PR TITLE
MSFS 2020 Sim Connect

### DIFF
--- a/WebMap/SimConnect.cfg
+++ b/WebMap/SimConnect.cfg
@@ -1,0 +1,49 @@
+; Example SimConnect client configurations
+
+; new FS pipe
+[SimConnect]
+Protocol=Pipe
+Port=Custom/SimConnect
+Address=127.0.0.1
+
+; Automatic detection, backward compatible with FSX
+[SimConnect.1]
+Protocol=Auto
+Address=
+Port=
+MaxReceiveSize=
+DisableNagle=
+
+[SimConnect.2]
+Protocol=Ipv6
+Port=501
+Address=127.0.0.1
+
+[SimConnect.3]
+Protocol=Ipv4
+Address=127.0.0.1
+Port=500
+
+; default FSX pipe
+[SimConnect.4]
+Protocol=Pipe
+Address=.
+
+; global pipe, use the configuration of the remote server
+[SimConnect.4]
+Protocol=Pipe
+Address=<remote computer address or name here>
+Port=<remote computer pipe name (matches Port name given in SimConnect.xml)>
+
+; global IPv6, use the configuration of the remote server
+[SimConnect.5]
+Protocol=IPv6
+Address=<remote computer address or name here>
+Port=<remote computer port number here>
+
+; global IPv4, use the configuration of the remote server
+[SimConnect.6]
+Protocol=IPv4
+Address=<remote computer address or name here>
+Port=<remote computer port number here>
+

--- a/WebMap/SimConnectInstance2020.cs
+++ b/WebMap/SimConnectInstance2020.cs
@@ -1,0 +1,176 @@
+﻿//using BeatlesBlog.SimConnect;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Interop;
+using Microsoft.FlightSimulator.SimConnect;
+
+namespace WebMap {
+
+    public class LatLon 
+    {
+        public double Latitude;
+        public double Longitude;
+    }
+
+
+    public class OpenEventArgs : EventArgs {
+        public string SimulatorName { get; private set; }
+        public OpenEventArgs(string SimulatorName) {
+            this.SimulatorName = SimulatorName;
+        }
+    }
+
+    class SimConnectInstance {
+        private const int WM_USER_SIMCONNECT = 0x0402;
+        private IntPtr handle;
+        private HwndSource handleSource;
+
+        private MainViewModel sender;
+        private SimConnect sc = null;
+        private System.Timers.Timer refreshTimer = new System.Timers.Timer(1000);
+        
+        private const string appName = "Web Map";
+
+        public EventHandler<OpenEventArgs> OpenEvent;
+        public EventHandler DisconnectEvent;
+        public LatLon userPos = new LatLon();
+        enum DEFINITIONS
+        {
+            Struct1,
+        }
+        // this is how you declare a data structure so that
+        // simconnect knows how to fill it/read it.
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi, Pack = 1)]
+        struct Struct1
+        {
+            public double latitude;
+            public double longitude;
+        };
+        enum DATA_REQUESTS
+        {
+            REQUEST_1,
+        };
+        protected virtual void OnRaiseOpenEvent(OpenEventArgs e) {
+            EventHandler<OpenEventArgs> handler = OpenEvent;
+            if (handler != null) {
+                handler(this, e);
+            }
+        }
+
+        protected virtual void OnRaiseDisconnectEvent(EventArgs e) {
+            EventHandler handler = DisconnectEvent;
+            if (handler != null) {
+                handler(this, e);
+            }
+        }
+
+        public SimConnectInstance(MainViewModel sender)
+        {
+
+            this.sender = sender;
+
+        }
+        ~SimConnectInstance()
+        {
+            if (handleSource != null)
+            {
+                handleSource.RemoveHook(HandleSimConnectEvents);
+            }
+        }
+        private IntPtr HandleSimConnectEvents(IntPtr hWnd, int message, IntPtr wParam, IntPtr lParam, ref bool isHandled)
+        {
+            isHandled = false;
+
+            switch (message)
+            {
+                case WM_USER_SIMCONNECT:
+                {
+                    if (sc != null)
+                    {
+                        sc.ReceiveMessage();
+                        isHandled = true;
+                    }
+                } 
+                break;
+            }
+            return IntPtr.Zero;
+        }
+        public void Connect() {
+            handle = new WindowInteropHelper(Application.Current.MainWindow).Handle;
+            handleSource = HwndSource.FromHwnd(handle); // Get source of handle in order to add event handlers to it
+            handleSource.AddHook(HandleSimConnectEvents);
+
+            if (sc == null) {
+                try {
+                    sc = new SimConnect(appName, handle, WM_USER_SIMCONNECT, null, 0);
+                    sc.OnRecvOpen += sc_OnRecvOpen;
+                    sc.OnRecvException += sc_OnRecvException;
+                    sc.OnRecvQuit += sc_OnRecvQuit;
+                    
+                    sc.AddToDataDefinition(DEFINITIONS.Struct1, "Plane Latitude", "degrees", SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SimConnect.SIMCONNECT_UNUSED);
+                    sc.AddToDataDefinition(DEFINITIONS.Struct1, "Plane Longitude", "degrees", SIMCONNECT_DATATYPE.FLOAT64, 0.0f, SimConnect.SIMCONNECT_UNUSED);
+                    
+                    sc.RegisterDataDefineStruct<Struct1>(DEFINITIONS.Struct1);
+                    
+                    sc.OnRecvSimobjectDataBytype += sc_OnRecvSimobjectData;
+                }
+
+                catch (Exception ex) {
+
+                    Console.WriteLine("Unable to connect to Sim");
+                }
+
+                refreshTimer.Elapsed += (sender, e) =>
+                {
+                    sc.RequestDataOnSimObjectType(DATA_REQUESTS.REQUEST_1, DEFINITIONS.Struct1, 0, SIMCONNECT_SIMOBJECT_TYPE.USER);
+                };
+                refreshTimer.Start();
+            }
+        }
+
+        public void Disconnect() {
+            refreshTimer.Stop();
+            sc.Dispose();
+            handleSource.RemoveHook(HandleSimConnectEvents);
+            sc = null;
+            sender.TryDisableWebServer();
+            OnRaiseDisconnectEvent(EventArgs.Empty);
+        }
+
+        private void sc_OnRecvOpen(SimConnect sender, SIMCONNECT_RECV_OPEN data) {
+            OnRaiseOpenEvent(new OpenEventArgs(data.szApplicationName));
+
+        }
+
+        private void sc_OnRecvException(SimConnect sender, SIMCONNECT_RECV_EXCEPTION data) {
+            Console.WriteLine(data.dwException);
+        }
+
+        private void sc_OnRecvQuit(SimConnect sender, SIMCONNECT_RECV data) {
+            Disconnect();
+        }
+
+        private void sc_OnRecvSimobjectData(SimConnect sender, SIMCONNECT_RECV_SIMOBJECT_DATA_BYTYPE data)
+        {
+            switch ((DATA_REQUESTS)data.dwRequestID)
+            {
+                case DATA_REQUESTS.REQUEST_1:
+                    Struct1 s1 = (Struct1)data.dwData[0];
+                    userPos.Latitude = s1.latitude;
+                    userPos.Longitude = s1.longitude;
+                 //   Console.WriteLine("lat: " + userPos.Latitude + " lon: " +userPos.Longitude);
+                    break;
+
+                default:
+                    Console.WriteLine("Unknown request ID: " + data.dwRequestID);
+                    break;
+            }
+        }
+    }
+}

--- a/WebMap/WebMap.csproj
+++ b/WebMap/WebMap.csproj
@@ -9,13 +9,14 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WebMap</RootNamespace>
     <AssemblyName>WebMap</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x64</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -41,10 +42,12 @@
     <StartupObject>WebMap.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BeatlesBlog.SimConnect">
-      <HintPath>..\..\..\Libraries\BeatlesBlog.SimConnect.SDK\Libs\BeatlesBlog.SimConnect.dll</HintPath>
+    <Reference Include="Microsoft.FlightSimulator.SimConnect, Version=10.0.62615.0, Culture=neutral, PublicKeyToken=5f523ae7e6e1b389, processorArchitecture=x86">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>.\Microsoft.FlightSimulator.SimConnect.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
@@ -65,7 +68,7 @@
     </ApplicationDefinition>
     <Compile Include="Program.cs" />
     <Compile Include="RelayCommand.cs" />
-    <Compile Include="SimConnectInstance.cs" />
+    <Compile Include="SimConnectInstance2020.cs" />
     <Compile Include="ViewModelBase.cs" />
     <Compile Include="WebServer.cs" />
     <Page Include="MainWindow.xaml">
@@ -119,6 +122,10 @@
       </EmbeddedResource>
     </ItemGroup>
   </Target>
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(ProjectDir)SimConnect.cfg" "." /Y
+xcopy "$(ProjectDir)SimConnect.dll" "." /Y</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
An entirely new SimConnectInstance (SimConnect2020) was created because it is so radically different from FSX and Prepar3d. You can decide how or if you want to merge it.  The new SimConnectInstance was tested in FSWebMap and verified working with MSFS-SDK-v0.6.0 DLLs.   You will need to get the SimConnect.DLL file from the SDK since it cannot be checked into the repo.  

This is the only moving map so far that will work with MSFS 2020 right now AKAIK :-)

Removed BeatlesBlog Simconnect
Added new reference to managed Sim Connect DLL
Added SimConnectInstance2020.cs
Platform Change to x64
Added SimConnect.cfg
